### PR TITLE
fix: header not always on top

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -2,7 +2,7 @@ import { Link } from 'react-router-dom';
 
 export const Header = () => {
   return (
-    <header className="sticky top-0 h-14 min-h-14 w-full flex justify-center items-center bg-black shadow shadow-green">
+    <header className="sticky top-0 z-[9999] h-14 min-h-14 w-full flex justify-center items-center bg-black shadow shadow-green">
       <h1 className="text-2xl font-thin">
         <Link to="/">SoundDeck</Link>
       </h1>


### PR DESCRIPTION
Fixes #8 

The header doesn't have a specified z index which may cause other components to scroll over it. This PR fixes that by given the header a z-index of 9999.