### PR TITLE
refactor: use separate route for playlist creation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,11 @@
             "version": "1.0.0",
             "dependencies": {
                 "@spotify/web-api-ts-sdk": "^1.2.0",
+                "@types/dompurify": "^3.0.5",
                 "clsx": "^2.1.1",
                 "crypto-hash": "^3.1.0",
+                "dompurify": "^3.1.6",
+                "html-entities": "^2.5.2",
                 "lucide-react": "^0.426.0",
                 "react": "^18.3.1",
                 "react-dom": "^18.3.1",
@@ -1136,6 +1139,15 @@
                 "@swc/counter": "^0.1.3"
             }
         },
+        "node_modules/@types/dompurify": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+            "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/trusted-types": "*"
+            }
+        },
         "node_modules/@types/estree": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
@@ -1166,6 +1178,12 @@
             "dependencies": {
                 "@types/react": "*"
             }
+        },
+        "node_modules/@types/trusted-types": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+            "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+            "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
             "version": "7.16.1",
@@ -2074,6 +2092,12 @@
             "engines": {
                 "node": ">=6.0.0"
             }
+        },
+        "node_modules/dompurify": {
+            "version": "3.1.6",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.6.tgz",
+            "integrity": "sha512-cTOAhc36AalkjtBpfG6O8JimdTMWNXjiePT2xQH/ppBGi/4uIpmj8eKyIkMJErXWARyINV/sB38yf8JCLF5pbQ==",
+            "license": "(MPL-2.0 OR Apache-2.0)"
         },
         "node_modules/eastasianwidth": {
             "version": "0.2.0",
@@ -3085,6 +3109,22 @@
             "engines": {
                 "node": ">= 0.4"
             }
+        },
+        "node_modules/html-entities": {
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.5.2.tgz",
+            "integrity": "sha512-K//PSRMQk4FZ78Kyau+mZurHn3FH0Vwr+H36eE0rPbeYkRRi9YxceYPhuN60UwWorxyKHhqoAJl2OFKa4BVtaA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/mdevils"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://patreon.com/mdevils"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/ignore": {
             "version": "5.3.1",
@@ -6146,6 +6186,14 @@
                 "@swc/counter": "^0.1.3"
             }
         },
+        "@types/dompurify": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+            "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+            "requires": {
+                "@types/trusted-types": "*"
+            }
+        },
         "@types/estree": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
@@ -6176,6 +6224,11 @@
             "requires": {
                 "@types/react": "*"
             }
+        },
+        "@types/trusted-types": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+            "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
         },
         "@typescript-eslint/eslint-plugin": {
             "version": "7.16.1",
@@ -6757,6 +6810,11 @@
             "requires": {
                 "esutils": "^2.0.2"
             }
+        },
+        "dompurify": {
+            "version": "3.1.6",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.6.tgz",
+            "integrity": "sha512-cTOAhc36AalkjtBpfG6O8JimdTMWNXjiePT2xQH/ppBGi/4uIpmj8eKyIkMJErXWARyINV/sB38yf8JCLF5pbQ=="
         },
         "eastasianwidth": {
             "version": "0.2.0",
@@ -7509,6 +7567,11 @@
             "requires": {
                 "function-bind": "^1.1.2"
             }
+        },
+        "html-entities": {
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.5.2.tgz",
+            "integrity": "sha512-K//PSRMQk4FZ78Kyau+mZurHn3FH0Vwr+H36eE0rPbeYkRRi9YxceYPhuN60UwWorxyKHhqoAJl2OFKa4BVtaA=="
         },
         "ignore": {
             "version": "5.3.1",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,11 @@
     },
     "dependencies": {
         "@spotify/web-api-ts-sdk": "^1.2.0",
+        "@types/dompurify": "^3.0.5",
         "clsx": "^2.1.1",
         "crypto-hash": "^3.1.0",
+        "dompurify": "^3.1.6",
+        "html-entities": "^2.5.2",
         "lucide-react": "^0.426.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",

--- a/src/components/button/IButtonProps.ts
+++ b/src/components/button/IButtonProps.ts
@@ -1,0 +1,11 @@
+import { ReactNode } from 'react';
+
+export interface IButtonProps {
+  content: string;
+  type: 'submit' | 'reset' | 'button';
+  icon?: ReactNode;
+  disabled?: boolean;
+  width?: number;
+  height?: number;
+  onClick: React.MouseEventHandler<HTMLButtonElement>;
+}

--- a/src/components/button/PrimaryButton.tsx
+++ b/src/components/button/PrimaryButton.tsx
@@ -1,17 +1,7 @@
 import clsx from 'clsx';
-import { ReactNode } from 'react';
+import { IButtonProps } from './IButtonProps';
 
-interface PrimaryButtonProps {
-  content: string;
-  type: 'submit' | 'reset' | 'button';
-  icon?: ReactNode;
-  disabled?: boolean;
-  width?: number;
-  height?: number;
-  onClick: React.MouseEventHandler<HTMLButtonElement>;
-}
-
-export const PrimaryButton = ({ content, type, icon, disabled, width, height, onClick }: PrimaryButtonProps) => {
+export const PrimaryButton = ({ content, type, icon, disabled, width, height, onClick }: IButtonProps) => {
   const css = clsx(
     'bg-green text-white px-3 py-2 rounded flex flex-row justify-center items-center gap-1 text-center cursor-pointer',
     disabled && 'opacity-75 cursor-not-allowed active:bg-green',

--- a/src/components/button/PrimaryButton.tsx
+++ b/src/components/button/PrimaryButton.tsx
@@ -3,6 +3,7 @@ import { ReactNode } from 'react';
 
 interface PrimaryButtonProps {
   content: string;
+  type: 'submit' | 'reset' | 'button';
   icon?: ReactNode;
   disabled?: boolean;
   width?: number;
@@ -10,7 +11,7 @@ interface PrimaryButtonProps {
   onClick: React.MouseEventHandler<HTMLButtonElement>;
 }
 
-export const PrimaryButton = ({ content, icon, disabled, width, height, onClick }: PrimaryButtonProps) => {
+export const PrimaryButton = ({ content, type, icon, disabled, width, height, onClick }: PrimaryButtonProps) => {
   const css = clsx(
     'bg-green text-white px-3 py-2 rounded flex flex-row justify-center items-center gap-1 text-center cursor-pointer',
     disabled && 'opacity-75 cursor-not-allowed active:bg-green',
@@ -18,7 +19,12 @@ export const PrimaryButton = ({ content, icon, disabled, width, height, onClick 
   );
 
   return (
-    <button className={css} onClick={(event) => !disabled && onClick(event)} style={{ width: width, height: height }}>
+    <button
+      type={type}
+      className={css}
+      onClick={(event) => !disabled && onClick(event)}
+      style={{ width: width, height: height }}
+    >
       {icon && <div className="align-middle">{icon}</div>}
       <p>{content}</p>
     </button>

--- a/src/components/button/SecondaryButton.tsx
+++ b/src/components/button/SecondaryButton.tsx
@@ -1,16 +1,7 @@
 import clsx from 'clsx';
-import { ReactNode } from 'react';
+import { IButtonProps } from './IButtonProps';
 
-interface SecondaryButtonProps {
-  content: string;
-  icon?: ReactNode;
-  disabled?: boolean;
-  width?: number;
-  height?: number;
-  onClick: React.MouseEventHandler<HTMLButtonElement>;
-}
-
-export const SecondaryButton = ({ content, icon, disabled, width, height, onClick }: SecondaryButtonProps) => {
+export const SecondaryButton = ({ content, type, icon, disabled, width, height, onClick }: IButtonProps) => {
   const css = clsx(
     'bg-purple text-white px-3 py-2 rounded flex flex-row justify-center items-center gap-1 text-center cursor-pointer',
     disabled && 'opacity-75 cursor-not-allowed active:bg-purple',
@@ -18,7 +9,12 @@ export const SecondaryButton = ({ content, icon, disabled, width, height, onClic
   );
 
   return (
-    <button className={css} onClick={(event) => !disabled && onClick(event)} style={{ width: width, height: height }}>
+    <button
+      type={type}
+      className={css}
+      onClick={(event) => !disabled && onClick(event)}
+      style={{ width: width, height: height }}
+    >
       {icon && <div className="align-middle">{icon}</div>}
       <p>{content}</p>
     </button>

--- a/src/components/playlist/PlaylistHeader.tsx
+++ b/src/components/playlist/PlaylistHeader.tsx
@@ -1,3 +1,6 @@
+import DOMPurify from 'dompurify';
+import { decode } from 'html-entities';
+
 // TODO: this should just take the playlist object returned from the api
 interface PlaylistHeaderProps {
   title: string;
@@ -24,7 +27,7 @@ export const PlaylistHeader = ({
         height={208}
       />
       <h1 className="text-lg">{title}</h1>
-      <p className="text-subdued text-xs">{description}</p>
+      <p className="text-subdued text-xs">{DOMPurify.sanitize(decode(description))}</p>
       <div className="flex flex-row items-center gap-2">
         <img className="h-4 rounded-full" src={ownerProfilePictureUrl} alt={`Profile picture of ${owner}`} />
         <p className="text-sm font-bold">{owner}</p>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,7 @@ import { Root } from './Root';
 import { DesignSystem } from './routes/DesignSystem';
 import { RootIndex } from './routes/RootIndex';
 import { Playlist } from './routes/[playlist]/Playlist';
+import { SavePlaylist } from './routes/[playlist]/SavePlaylist';
 import { Login } from './routes/login/Login';
 import { OAuth2 } from './routes/oauth2/OAuth2';
 import { Search } from './routes/search/Search';
@@ -36,6 +37,10 @@ const router = createBrowserRouter([
           {
             path: '/playlist/:playlistId',
             element: <Playlist />,
+          },
+          {
+            path: '/playlist/:playlistId/save',
+            element: <SavePlaylist />,
           },
         ],
       },

--- a/src/routes/DesignSystem.tsx
+++ b/src/routes/DesignSystem.tsx
@@ -22,6 +22,7 @@ export const DesignSystem = () => {
         </Fab>
         <PrimaryButton
           content="Login with Spotify"
+          type="button"
           icon={<img className="w-4 aspect-square" src="/img/spotify/icons/Spotify_Icon_Black.png"></img>}
           onClick={() => console.log('login button clicked')}
         />
@@ -29,6 +30,7 @@ export const DesignSystem = () => {
       <div>
         <SecondaryButton
           content="Login with Spotify"
+          type="button"
           icon={<img className="w-4 aspect-square" src="/img/spotify/icons/Spotify_Icon_White.png"></img>}
           onClick={() => console.log('login button clicked')}
         />
@@ -63,7 +65,7 @@ export const DesignSystem = () => {
       </div>
 
       <EmptyState content="Save some mixes and watch them appear here.">
-        <PrimaryButton content="Search Mixes" onClick={() => {}} />
+        <PrimaryButton content="Search Mixes" type="button" onClick={() => {}} />
       </EmptyState>
 
       <div>

--- a/src/routes/[playlist]/SavePlaylist.tsx
+++ b/src/routes/[playlist]/SavePlaylist.tsx
@@ -85,7 +85,7 @@ export const SavePlaylist = () => {
             onChange={(event) => setNewPlaylistName(event.target.value)}
           />
           <div className="flex flex-row justify-around gap-3">
-            <SecondaryButton content="Cancel" onClick={() => navigate(-1)} width={80} />
+            <SecondaryButton content="Cancel" type="button" onClick={() => navigate(-1)} width={80} />
             <PrimaryButton content="Save" type="submit" onClick={() => void onSubmit()} disabled={false} width={80} />
           </div>
         </>

--- a/src/routes/[playlist]/SavePlaylist.tsx
+++ b/src/routes/[playlist]/SavePlaylist.tsx
@@ -1,0 +1,97 @@
+import { PlaylistedTrack, SpotifyApi, Track } from '@spotify/web-api-ts-sdk';
+import { useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { PrimaryButton } from '../../components/button/PrimaryButton';
+import { SecondaryButton } from '../../components/button/SecondaryButton';
+import { TextInput } from '../../components/inputs/TextInput';
+import { BasicSpinner } from '../../components/spinners/BasicSpinner';
+import { useSpotify } from '../../hooks/useSpotify';
+
+const recursivelyGetPlaylistItems = async (spotify: SpotifyApi, playlistId: string, offset = 0) => {
+  let items: PlaylistedTrack<Track>[] = [];
+
+  const playlistItems = await spotify.playlists.getPlaylistItems(playlistId, undefined, undefined, 50, offset);
+
+  items = items.concat(playlistItems.items);
+
+  if (playlistItems.next) {
+    offset += playlistItems.limit;
+    items = items.concat(await recursivelyGetPlaylistItems(spotify, playlistId, offset));
+  }
+
+  return items;
+};
+
+export const SavePlaylist = () => {
+  const navigate = useNavigate();
+  const spotify = useSpotify();
+
+  const { playlistId } = useParams();
+
+  const [newPlaylistName, setNewPlaylistName] = useState('');
+  const [creatingPlaylist, setCreatingPlaylist] = useState(false);
+
+  const onSubmit = async () => {
+    if (!newPlaylistName || !playlistId) {
+      return;
+    }
+
+    setCreatingPlaylist(true);
+
+    const allSourcePlaylistItems = await recursivelyGetPlaylistItems(spotify, playlistId);
+    if (allSourcePlaylistItems.length < 1) {
+      console.log('No source playlist items received. Returning.');
+      return;
+    }
+
+    const itemUris = allSourcePlaylistItems
+      .filter((item) => item.track) // for some unknown reason the api sometimes returns items with their track set to null.
+      .map((item) => {
+        return item.track.uri;
+      });
+
+    const today = new Date();
+    const newPlaylist = await spotify.playlists.createPlaylist((await spotify.currentUser.profile()).id, {
+      name: newPlaylistName,
+      public: false,
+      collaborative: false,
+      description: `Created by SoundDeck at ${today.getUTCDate().toString()}/${(today.getUTCMonth() + 1).toString()}/${today.getUTCFullYear().toString()}.`,
+    });
+
+    try {
+      await spotify.playlists.addItemsToPlaylist(newPlaylist.id, itemUris);
+    } catch (e) {
+      console.log(
+        "Error occurred while trying to add items to new playlist. Removing playlist from the user's library.",
+      );
+      console.error(e);
+
+      try {
+        await spotify.currentUser.playlists.unfollow(newPlaylist.id);
+      } catch (e) {
+        console.error('Failed to unfollow playlist (after unsuccessful creation).', e);
+      }
+    }
+
+    navigate(`/playlist/${newPlaylist.id}`, { replace: true });
+  };
+
+  return (
+    <div className="fixed inset-0 backdrop-blur-lg bg-transparent bg-gradient-to-b from-purple/50 to-green/50 flex flex-col justify-center items-center gap-5">
+      {!creatingPlaylist ? (
+        <>
+          <TextInput
+            placeholder="Give your playlist a name."
+            onChange={(event) => setNewPlaylistName(event.target.value)}
+          />
+          <div className="flex flex-row justify-around gap-3">
+            <SecondaryButton content="Cancel" onClick={() => navigate(-1)} width={80} />
+            <PrimaryButton content="Save" type="submit" onClick={() => void onSubmit()} disabled={false} width={80} />
+          </div>
+        </>
+      ) : (
+        <BasicSpinner />
+      )}
+    </div>
+  );
+};

--- a/src/routes/login/Login.tsx
+++ b/src/routes/login/Login.tsx
@@ -49,6 +49,7 @@ export const Login = () => {
         <h2 className="text-2xl font-medium text-center">Log in to Spotify</h2>
         <PrimaryButton
           content="Log In with Spotify"
+          type="button"
           onClick={() => navigate('/oauth2')}
           icon={<img src="/img/spotify/icons/Spotify_Icon_White.png" alt="Spotify Icon" width={20} height={20} />}
         />


### PR DESCRIPTION
This PR separates the playlist creation to it's own route `/playlist/:playlistId/save`.

It also cleans up the entire playlist creation logic including proper error handling. Created playlists are now removed from the users library if the items couldn't be added to it. That way it looks to the user as if the playlist was never created.