### PR TITLE
feat: prevent Segoe UI

### DIFF
--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -6,5 +6,6 @@
     * {
         scrollbar-color: #afafaf55 #121212;
         scrollbar-width: thin;
+        font-family: Bahnschrift, system-ui;
     }
 }


### PR DESCRIPTION
Segoe UI is not usable due to not being vertically centered. Therefore, we use Bahnschrift on Windows systems and the system-ui font on all other devices.